### PR TITLE
refactor: rename petition envs to single space

### DIFF
--- a/apps/dashboard/shared/dao-config/arb.ts
+++ b/apps/dashboard/shared/dao-config/arb.ts
@@ -14,10 +14,10 @@ export const ARB: DaoConfiguration = {
   supportStage: SupportStageEnum.ELECTION,
   tokenDistribution: true,
   showSupport:
-    process.env.NEXT_PUBLIC_ARB_SNAPSHOT_PROPOSAL && process.env.NEXT_PUBLIC_ARB_SNAPSHOT_SPACE
+    process.env.NEXT_PUBLIC_SNAPSHOT_PROPOSAL_ARB && process.env.NEXT_PUBLIC_SNAPSHOT_SPACE
       ? {
-        snapshotProposal: process.env.NEXT_PUBLIC_ARB_SNAPSHOT_PROPOSAL,
-        snapshotSpace: process.env.NEXT_PUBLIC_ARB_SNAPSHOT_SPACE,
+        snapshotProposal: process.env.NEXT_PUBLIC_SNAPSHOT_PROPOSAL_ARB,
+        snapshotSpace: process.env.NEXT_PUBLIC_SNAPSHOT_SPACE,
       }
       : undefined,
   attackProfitability: {


### PR DESCRIPTION
Unifying the proposal space to be `petition.anticapture.com` from the envs and the proposal ID we've created on the given space