### PR TITLE
chore: add codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+* @heronlancellot @lgahdl @eduramme @lucaspicolloo @LeonardoVieira1630 @alextnetto
+
+apps/dashboard/* @isadorable-png

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
-* @heronlancellot @lgahdl @eduramme @lucaspicolloo @LeonardoVieira1630 @alextnetto
+* @heronlancellot @lgahdl @edulennert @pikonha @LeonardoVieira1630 @alextnetto
 
 apps/dashboard/* @isadorable-png


### PR DESCRIPTION
Adding @isadorable-png as the frontend owner is meant to ensure the PR has her approval before being merged