### PR TITLE
fix: Calculating avgTimeBeforeEnd (was undone);

### DIFF
--- a/apps/indexer/src/api/controller/proposals-activity.controller.ts
+++ b/apps/indexer/src/api/controller/proposals-activity.controller.ts
@@ -73,9 +73,9 @@ export function proposalsActivity(
                       endBlock: z.string(),
                       timestamp: z.string(),
                       status: z.string(),
-                      forVotes: z.number(), // default 0
-                      againstVotes: z.number(), // default 0
-                      abstainVotes: z.number(), // default 0
+                      forVotes: z.string(),
+                      againstVotes: z.string(),
+                      abstainVotes: z.string(),
                     }),
                     userVote: z
                       .object({

--- a/apps/indexer/src/api/repositories/drizzle.ts
+++ b/apps/indexer/src/api/repositories/drizzle.ts
@@ -14,14 +14,14 @@ export class DrizzleRepository {
     const query = sql`
       WITH old_data AS (
         SELECT db.average as old_amount
-        FROM dao_metrics_day_buckets db
+        FROM anticapture.dao_metrics_day_buckets db
         WHERE db."metricType" = ${metricType}
         AND db."date" <= ${this.now() - days}
         ORDER BY db."date" desc LIMIT 1
       ),
       current_data AS (
         SELECT db.average as current_amount
-        FROM dao_metrics_day_buckets db
+        FROM anticapture.dao_metrics_day_buckets db
         WHERE db."metricType" = ${metricType}
         ORDER BY db."date" DESC LIMIT 1
       )
@@ -32,7 +32,7 @@ export class DrizzleRepository {
     `;
 
     const result = await db.execute<{ oldValue: string; currentValue: string }>(
-      query
+      query,
     );
     return result.rows[0];
   }
@@ -40,7 +40,7 @@ export class DrizzleRepository {
   async getActiveSupply(days: DaysEnum) {
     const query = sql`
       SELECT COALESCE(SUM(ap."voting_power"), 0) as "activeSupply"
-      FROM "account_power" ap
+      FROM anticapture."account_power" ap
       WHERE ap."last_vote_timestamp" >= ${this.now() - days}
     `;
     const result = await db.execute<ActiveSupplyQueryResult>(query);
@@ -51,12 +51,12 @@ export class DrizzleRepository {
     const query = sql`
       WITH old_proposals AS (
         SELECT COUNT(*) AS "oldProposalsLaunched"
-        FROM "proposals_onchain" p
+        FROM anticapture."proposals_onchain" p
         WHERE p.timestamp <= ${this.now() - days}
       ),
       current_proposals AS (
         SELECT COUNT(*) AS "currentProposalsLaunched"
-        FROM "proposals_onchain" p
+        FROM anticapture."proposals_onchain" p
       )
       SELECT * FROM current_proposals
       JOIN old_proposals ON 1=1;
@@ -69,12 +69,12 @@ export class DrizzleRepository {
     const query = sql`
       WITH old_votes AS (
         SELECT COUNT(*) AS "oldVotes"
-        FROM "votes_onchain" v
+        FROM anticapture."votes_onchain" v
         WHERE v.timestamp <= ${this.now() - days}
       ),
       current_votes AS (
         SELECT COUNT(*) AS "currentVotes"
-        FROM "votes_onchain" v
+        FROM anticapture."votes_onchain" v
       )
       SELECT * FROM current_votes
       JOIN old_votes ON 1=1;
@@ -87,13 +87,13 @@ export class DrizzleRepository {
     const query = sql`
       WITH old_average_turnout AS (
         SELECT AVG(po."for_votes" + po."against_votes" + po."abstain_votes") AS "oldAverageTurnout"
-        FROM "proposals_onchain" po
+        FROM anticapture."proposals_onchain" po
         WHERE po.timestamp <= ${this.now() - days}
         AND po.status != 'CANCELED'
       ),
       current_average_turnout AS (
         SELECT AVG(po."for_votes" + po."against_votes" + po."abstain_votes") AS "currentAverageTurnout"
-        FROM "proposals_onchain" po
+        FROM anticapture."proposals_onchain" po
         WHERE po.status != 'CANCELED'
       )
       SELECT * FROM current_average_turnout

--- a/apps/indexer/src/api/repositories/drizzle.ts
+++ b/apps/indexer/src/api/repositories/drizzle.ts
@@ -14,14 +14,14 @@ export class DrizzleRepository {
     const query = sql`
       WITH old_data AS (
         SELECT db.average as old_amount
-        FROM anticapture.dao_metrics_day_buckets db
+        FROM dao_metrics_day_buckets db
         WHERE db."metricType" = ${metricType}
         AND db."date" <= ${this.now() - days}
         ORDER BY db."date" desc LIMIT 1
       ),
       current_data AS (
         SELECT db.average as current_amount
-        FROM anticapture.dao_metrics_day_buckets db
+        FROM dao_metrics_day_buckets db
         WHERE db."metricType" = ${metricType}
         ORDER BY db."date" DESC LIMIT 1
       )
@@ -40,7 +40,7 @@ export class DrizzleRepository {
   async getActiveSupply(days: DaysEnum) {
     const query = sql`
       SELECT COALESCE(SUM(ap."voting_power"), 0) as "activeSupply"
-      FROM anticapture."account_power" ap
+      FROM "account_power" ap
       WHERE ap."last_vote_timestamp" >= ${this.now() - days}
     `;
     const result = await db.execute<ActiveSupplyQueryResult>(query);
@@ -51,12 +51,12 @@ export class DrizzleRepository {
     const query = sql`
       WITH old_proposals AS (
         SELECT COUNT(*) AS "oldProposalsLaunched"
-        FROM anticapture."proposals_onchain" p
+        FROM "proposals_onchain" p
         WHERE p.timestamp <= ${this.now() - days}
       ),
       current_proposals AS (
         SELECT COUNT(*) AS "currentProposalsLaunched"
-        FROM anticapture."proposals_onchain" p
+        FROM "proposals_onchain" p
       )
       SELECT * FROM current_proposals
       JOIN old_proposals ON 1=1;
@@ -69,12 +69,12 @@ export class DrizzleRepository {
     const query = sql`
       WITH old_votes AS (
         SELECT COUNT(*) AS "oldVotes"
-        FROM anticapture."votes_onchain" v
+        FROM "votes_onchain" v
         WHERE v.timestamp <= ${this.now() - days}
       ),
       current_votes AS (
         SELECT COUNT(*) AS "currentVotes"
-        FROM anticapture."votes_onchain" v
+        FROM "votes_onchain" v
       )
       SELECT * FROM current_votes
       JOIN old_votes ON 1=1;
@@ -87,13 +87,13 @@ export class DrizzleRepository {
     const query = sql`
       WITH old_average_turnout AS (
         SELECT AVG(po."for_votes" + po."against_votes" + po."abstain_votes") AS "oldAverageTurnout"
-        FROM anticapture."proposals_onchain" po
+        FROM "proposals_onchain" po
         WHERE po.timestamp <= ${this.now() - days}
         AND po.status != 'CANCELED'
       ),
       current_average_turnout AS (
         SELECT AVG(po."for_votes" + po."against_votes" + po."abstain_votes") AS "currentAverageTurnout"
-        FROM anticapture."proposals_onchain" po
+        FROM "proposals_onchain" po
         WHERE po.status != 'CANCELED'
       )
       SELECT * FROM current_average_turnout

--- a/apps/indexer/src/api/repositories/proposals-activity.repository.ts
+++ b/apps/indexer/src/api/repositories/proposals-activity.repository.ts
@@ -74,7 +74,7 @@ export class DrizzleProposalsActivityRepository
   async getDaoVotingPeriod(daoId: DaoIdEnum): Promise<number> {
     const query = sql`
       SELECT voting_period
-      FROM dao
+      FROM anticapture.dao
       WHERE id = ${daoId}
       LIMIT 1
     `;
@@ -98,7 +98,7 @@ export class DrizzleProposalsActivityRepository
       SELECT id, dao_id, proposer_account_id, description, start_block, end_block, 
              timestamp, status, for_votes, against_votes, abstain_votes,
              (timestamp + ${votingPeriodSeconds}) as proposal_end_timestamp
-      FROM proposals_onchain
+      FROM anticapture.proposals_onchain
       WHERE (timestamp + ${votingPeriodSeconds}) >= ${activityStart}
       ORDER BY timestamp DESC
     `;
@@ -116,7 +116,7 @@ export class DrizzleProposalsActivityRepository
 
     const query = sql`
       SELECT id, voter_account_id, proposal_id, support, voting_power, reason, timestamp
-      FROM votes_onchain
+      FROM anticapture.votes_onchain
       WHERE voter_account_id = ${address}
         AND dao_id = ${daoId}
         AND proposal_id IN (${sql.raw(proposalIds.map((id) => `'${id}'`).join(","))})

--- a/apps/indexer/src/api/repositories/proposals-activity.repository.ts
+++ b/apps/indexer/src/api/repositories/proposals-activity.repository.ts
@@ -74,7 +74,7 @@ export class DrizzleProposalsActivityRepository
   async getDaoVotingPeriod(daoId: DaoIdEnum): Promise<number> {
     const query = sql`
       SELECT voting_period
-      FROM anticapture.dao
+      FROM dao
       WHERE id = ${daoId}
       LIMIT 1
     `;
@@ -98,7 +98,7 @@ export class DrizzleProposalsActivityRepository
       SELECT id, dao_id, proposer_account_id, description, start_block, end_block, 
              timestamp, status, for_votes, against_votes, abstain_votes,
              (timestamp + ${votingPeriodSeconds}) as proposal_end_timestamp
-      FROM anticapture.proposals_onchain
+      FROM proposals_onchain
       WHERE (timestamp + ${votingPeriodSeconds}) >= ${activityStart}
       ORDER BY timestamp DESC
     `;
@@ -116,7 +116,7 @@ export class DrizzleProposalsActivityRepository
 
     const query = sql`
       SELECT id, voter_account_id, proposal_id, support, voting_power, reason, timestamp
-      FROM anticapture.votes_onchain
+      FROM votes_onchain
       WHERE voter_account_id = ${address}
         AND dao_id = ${daoId}
         AND proposal_id IN (${sql.raw(proposalIds.map((id) => `'${id}'`).join(","))})

--- a/apps/indexer/src/api/services/proposals-activity/proposals-activity.service.ts
+++ b/apps/indexer/src/api/services/proposals-activity/proposals-activity.service.ts
@@ -196,8 +196,8 @@ export class ProposalsActivityService {
     return {
       winRate: Math.round(winRate * 100) / 100,
       yesRate: Math.round(yesRate * 100) / 100,
-      avgTimeBeforeEnd: Math.round(avgTimeBeforeEnd), // Round to nearest second
-    };
+      avgTimeBeforeEnd, // This parameter is in seconds
+    }
   }
 
   private calculateWinRate(proposals: DbProposal[], userVotes: DbVote[]) {
@@ -266,7 +266,7 @@ export class ProposalsActivityService {
       }
     }
 
-    return validVotes > 0 ? totalTimeBeforeEnd / validVotes : 0;
+    return validVotes > 0 ? Math.round(totalTimeBeforeEnd / validVotes) : 0;
   }
 
   private createEmptyActivity(

--- a/apps/indexer/src/api/services/proposals-activity/proposals-activity.service.ts
+++ b/apps/indexer/src/api/services/proposals-activity/proposals-activity.service.ts
@@ -28,9 +28,10 @@ export interface ProposalWithUserVote {
     endBlock: string;
     timestamp: string;
     status: string;
-    forVotes: number;
-    againstVotes: number;
-    abstainVotes: number;
+    forVotes: string;
+    againstVotes: string;
+    abstainVotes: string;
+    proposalEndTimestamp: string;
   };
   userVote: {
     id: string;
@@ -147,9 +148,10 @@ export class ProposalsActivityService {
           endBlock: proposal.end_block,
           timestamp: proposal.timestamp,
           status: proposal.status,
-          forVotes: Number(proposal.for_votes || 0),
-          againstVotes: Number(proposal.against_votes || 0),
-          abstainVotes: Number(proposal.abstain_votes || 0),
+          forVotes: proposal.for_votes,
+          againstVotes: proposal.against_votes,
+          abstainVotes: proposal.abstain_votes,
+          proposalEndTimestamp: proposal.proposal_end_timestamp,
         },
         userVote: vote
           ? {
@@ -185,10 +187,16 @@ export class ProposalsActivityService {
         ? (winningVotes / finishedProposalsVoted) * 100
         : 0;
 
+    // Calculate average time before end
+    const avgTimeBeforeEnd = this.calculateAvgTimeBeforeEnd(
+      proposals,
+      userVotes,
+    );
+
     return {
       winRate: Math.round(winRate * 100) / 100,
       yesRate: Math.round(yesRate * 100) / 100,
-      avgTimeBeforeEnd: 0, // TODO: Implement proper block-to-timestamp conversion
+      avgTimeBeforeEnd: Math.round(avgTimeBeforeEnd), // Round to nearest second
     };
   }
 
@@ -225,6 +233,40 @@ export class ProposalsActivityService {
   private getWinningSide(status: string): string {
     const statusUpper = status.toUpperCase();
     return statusUpper === "EXECUTED" ? "1" : "0"; // "1" = For, "0" = Against
+  }
+
+  private calculateAvgTimeBeforeEnd(
+    proposals: DbProposal[],
+    userVotes: DbVote[],
+  ): number {
+    if (userVotes.length === 0) {
+      return 0;
+    }
+
+    const proposalMap = new Map(proposals.map((p) => [p.id, p]));
+    let totalTimeBeforeEnd = 0;
+    let validVotes = 0;
+
+    for (const vote of userVotes) {
+      const proposal = proposalMap.get(vote.proposal_id);
+      if (!proposal || !proposal.proposal_end_timestamp) {
+        continue;
+      }
+
+      const voteTimestamp = Number(vote.timestamp);
+      const proposalEndTimestamp = Number(proposal.proposal_end_timestamp);
+
+      // Calculate time difference in seconds
+      const timeBeforeEndSeconds = proposalEndTimestamp - voteTimestamp;
+
+      // Only count positive values (votes cast before proposal ended)
+      if (timeBeforeEndSeconds > 0) {
+        totalTimeBeforeEnd += timeBeforeEndSeconds;
+        validVotes++;
+      }
+    }
+
+    return validVotes > 0 ? totalTimeBeforeEnd / validVotes : 0;
   }
 
   private createEmptyActivity(


### PR DESCRIPTION
fix: Adding view schema name before the queries;

This PR is to fix 2 bugs in the Proposals Activity HTTP Endpoint:
- Serialization error for bigints in the forVotes, abstainVotes and againstVotes;
- avgTimeBeforeEnd was not being calculated